### PR TITLE
fix(parser): Fix decimal grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Lago Expression
+
+A cross-platform expression parser and evaluator for Lago, supporting multiple programming languages and platforms.
+
+## Development
+
+### Prerequisites
+
+- Rust (latest stable)
+- Ruby (for Ruby bindings)
+- Node.js (for JavaScript bindings)
+- Go (for Go bindings)
+
+### Expression Core
+
+This is the core expression parser and evaluator. It is written in Rust and is used by the other bindings.
+
+```bash
+# Build all components
+cargo build -p expression-core
+```
+
+#### Testing
+
+```bash
+cargo test -p expression-core
+```
+
+### Expression Ruby
+
+This is the Ruby extension for Lago Expression.
+
+See [expression-ruby/README.md](expression-ruby/README.md) for more information.
+
+### Expression JS
+
+See [expression-js/README.md](expression-js/README.md) for more information.

--- a/expression-core/src/evaluate.rs
+++ b/expression-core/src/evaluate.rs
@@ -198,7 +198,7 @@ mod tests {
             Ok(expr) => {
                 assert_eq!(expr, expected_result)
             }
-            Err(e) => panic!("Failed to evalaute expression: {:?}", e),
+            Err(e) => panic!("Failed to evaluate expression: {:?}", e),
         }
     }
 
@@ -387,6 +387,20 @@ mod tests {
             Expression::String("test".into()),
             Expression::String("-".into()),
             Expression::String("123".into()),
+        ]));
+        let event = Default::default();
+        evaluate_and_compare(expr, &event, ExpressionValue::String("test-123".into()));
+    }
+
+    #[test]
+    fn test_evaluate_nested_functions() {
+        let expr = Expression::Function(Function::Concat(vec![
+            Expression::String("test".into()),
+            Expression::String("-".into()),
+            Expression::Function(Function::Round(
+                Box::new(Expression::Decimal("123".parse::<BigDecimal>().unwrap())),
+                None,
+            )),
         ]));
         let event = Default::default();
         evaluate_and_compare(expr, &event, ExpressionValue::String("test-123".into()));

--- a/expression-core/src/grammar.pest
+++ b/expression-core/src/grammar.pest
@@ -20,7 +20,7 @@ event_code       =  { "code" }
 property_name    =  { ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 
 variable = @{ variable_prefix ~ event_attributes }
-decimal  = @{ (ASCII_DIGIT | ".")+ }
+decimal  = @{ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
 
 unary_minus =  { "-" }
 primary     = _{ function | variable | decimal | string | "(" ~ expr ~ ")" }

--- a/expression-core/src/parser.rs
+++ b/expression-core/src/parser.rs
@@ -191,6 +191,16 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_invalid_decimal() {
+        let result = ExpressionParser::parse_expression("1.1.1");
+        assert!(
+            matches!(result.as_ref().unwrap_err(), ParseError::FailedToParse(_)),
+            "Expected FailedToParse error, got different error: {:?}",
+            result.unwrap_err()
+        );
+    }
+
+    #[test]
     fn test_parse_event_attribute() {
         parse_and_compare(
             "event.timestamp",

--- a/expression-js/README.md
+++ b/expression-js/README.md
@@ -1,0 +1,15 @@
+# Lago Expression JS
+
+This is the JS extension for Lago Expression.
+
+## Setup
+
+```
+npm install
+```
+
+## Build
+
+```
+npm run build
+```

--- a/expression-ruby/README.md
+++ b/expression-ruby/README.md
@@ -1,0 +1,21 @@
+# Lago Expression Ruby
+
+This is the Ruby extension for Lago Expression.
+
+## Setup
+
+```
+bundle install
+```
+
+## Build
+
+```
+bundle exec rake compile
+```
+
+## Test
+
+```
+bundle exec rake spec
+```


### PR DESCRIPTION
The grammer for parsing decimal numbers was incorrect, leading `1.0.1` to be parsed as a valid decimal grammar. Fortunately, this still caused a `FailedToParseBigDecimal` error during parsing, but it should be a `FailedToParse` error instead:

```sh
test parser::tests::test_parse_invalid_decimal ... FAILED

failures:

---- parser::tests::test_parse_invalid_decimal stdout ----

thread 'parser::tests::test_parse_invalid_decimal' panicked at expression-core/src/parser.rs:196:9:
Expected FailedToParse error, got different error: FailedToParseBigDecimal(ParseBigInt(ParseBigIntError { kind: InvalidDigit }))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This commit fixes the grammar to correctly parse decimal numbers and ensures that invalid decimal numbers like `1.0.1` are caught as `FailedToParse` errors.

Note that the grammar still allows `00012.1` as a valid decimal number. This will be properly evaluated by the evaluator as `12.1`.

This PR also adds:

- `README`s to improve development workflow.
- A test for nested function calls.
- A typo fix in the parser.