### PR TITLE
misc: bump version to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "expression-core"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "bigdecimal",
  "lazy_static",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "expression-go"
-version = "0.1.3"
+version = "0.1.6"
 dependencies = [
  "cbindgen",
  "expression-core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "lago-expression"
-version = "0.1.4"
+version = "0.1.6"
 dependencies = [
  "bigdecimal",
  "console_error_panic_hook",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "lago_expression"
-version = "0.1.3"
+version = "0.1.6"
 dependencies = [
  "expression-core",
  "magnus",

--- a/expression-core/Cargo.toml
+++ b/expression-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expression-core"
-version = "0.1.4"
+version = "0.1.6"
 edition = "2021"
 
 [dependencies]

--- a/expression-go/Cargo.toml
+++ b/expression-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expression-go"
-version = "0.1.3"
+version = "0.1.6"
 edition = "2021"
 publish = false
 

--- a/expression-js/Cargo.toml
+++ b/expression-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-expression"
-version = "0.1.4"
+version = "0.1.6"
 edition = "2021"
 
 [lib]

--- a/expression-ruby/ext/lago_expression/Cargo.toml
+++ b/expression-ruby/ext/lago_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago_expression"
-version = "0.1.3"
+version = "0.1.6"
 edition = "2021"
 publish = false
 

--- a/expression-ruby/lago-expression.gemspec
+++ b/expression-ruby/lago-expression.gemspec
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |spec|
   spec.name = 'lago-expression'
-  spec.version = '0.1.5'
+  spec.version = '0.1.6'
   spec.summary = 'gem supporting sql expression evaluation in ruby'
   spec.authors = ['Lago']
   spec.required_ruby_version = '~> 3.4'
-  spec.required_rubygems_version = ">= 3.3.11"
+  spec.required_rubygems_version = '>= 3.3.11'
 
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
   spec.extensions = ['ext/lago_expression/Cargo.toml']
 
   spec.add_dependency 'bigdecimal'

--- a/expression-ruby/lib/lago-expression.rb
+++ b/expression-ruby/lib/lago-expression.rb
@@ -3,5 +3,5 @@ require 'bigdecimal/util'
 require_relative 'lago_expression/lago_expression'
 
 module Lago
-  VERSION = '0.1.5'.freeze
+  VERSION = '0.1.6'.freeze
 end


### PR DESCRIPTION
Bump packages version to 0.1.6
Will then 
1. add a GH tag with this version
2. run the NPM publish workflow

Preferred to tag a new version for a fresh start