### PR TITLE
feat: Add min/max expressions

### DIFF
--- a/expression-core/src/evaluate.rs
+++ b/expression-core/src/evaluate.rs
@@ -42,6 +42,9 @@ impl ExpressionValue {
 
 #[derive(Error, Debug)]
 pub enum ExpressionError {
+    #[error("Expected non-empty argument list")]
+    EmptyArgumentList,
+
     #[error("Expected a decimal")]
     ExpectedDecimal,
 
@@ -121,16 +124,16 @@ impl Function {
                     .map(|e| e.evaluate(event).and_then(|v| v.to_decimal()))
                     .collect::<EvaluationResult<Vec<BigDecimal>>>()?
                     .into_iter()
-                    .min().ok_or(ExpressionError::ExpectedDecimal)?;
+                    .min().ok_or(ExpressionError::EmptyArgumentList)?;
                 Ok(ExpressionValue::Number(min_value))
-            },
+            }
             Function::Max(args) => {
                 let max_value = args
                     .iter()
                     .map(|e| e.evaluate(event).and_then(|v| v.to_decimal()))
                     .collect::<EvaluationResult<Vec<BigDecimal>>>()?
                     .into_iter()
-                    .max().ok_or(ExpressionError::ExpectedDecimal)?;
+                    .max().ok_or(ExpressionError::EmptyArgumentList)?;
                 Ok(ExpressionValue::Number(max_value))
             }
         }

--- a/expression-core/src/evaluate.rs
+++ b/expression-core/src/evaluate.rs
@@ -115,6 +115,24 @@ impl Function {
                 event,
                 RoundingMode::Floor,
             ),
+            Function::Min(args) => {
+                let min_value = args
+                    .iter()
+                    .map(|e| e.evaluate(event).and_then(|v| v.to_decimal()))
+                    .collect::<EvaluationResult<Vec<BigDecimal>>>()?
+                    .into_iter()
+                    .min().ok_or(ExpressionError::ExpectedDecimal)?;
+                Ok(ExpressionValue::Number(min_value))
+            },
+            Function::Max(args) => {
+                let max_value = args
+                    .iter()
+                    .map(|e| e.evaluate(event).and_then(|v| v.to_decimal()))
+                    .collect::<EvaluationResult<Vec<BigDecimal>>>()?
+                    .into_iter()
+                    .max().ok_or(ExpressionError::ExpectedDecimal)?;
+                Ok(ExpressionValue::Number(max_value))
+            }
         }
     }
 }

--- a/expression-core/src/grammar.pest
+++ b/expression-core/src/grammar.pest
@@ -1,10 +1,12 @@
 function = { function_name ~ "(" ~ function_args ~ ")" }
 
-function_name = _{ ceil | concat | round | floor }
+function_name = _{ ceil | concat | round | floor | min | max }
 ceil          =  { "ceil" | "CEIL" | "Ceil" }
 concat        =  { "concat" | "CONCAT" | "Concat" }
 round         =  { "round" | "ROUND" | "Round" }
 floor         =  { "floor" | "FLOOR" | "Floor" }
+min           =  {"min" | "MIN" | "Min"}
+max           =  {"max" | "MAX" | "Max"}
 
 function_args = _{ expr ~ ("," ~ expr)* }
 

--- a/expression-core/src/parser.rs
+++ b/expression-core/src/parser.rs
@@ -26,6 +26,8 @@ pub enum Function {
     Ceil(Box<Expression>, Option<Box<Expression>>),
     Round(Box<Expression>, Option<Box<Expression>>),
     Floor(Box<Expression>, Option<Box<Expression>>),
+    Min(Vec<Box<Expression>>),
+    Max(Vec<Box<Expression>>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -83,6 +85,20 @@ fn parse_function(pairs: Pairs<Rule>) -> ParseResult<Function> {
         Rule::ceil => parse_function_with_args(Function::Ceil, iter)?,
         Rule::round => parse_function_with_args(Function::Round, iter)?,
         Rule::floor => parse_function_with_args(Function::Floor, iter)?,
+        Rule::min => {
+           let args = iter
+                .map(|r| parse_expr(r.into_inner()).map(Box::new))
+                .collect::<ParseResult<Vec<Box<Expression>>>>()?;
+
+            Function::Min(args)
+        }
+        Rule::max => {
+            let args = iter
+                .map(|r| parse_expr(r.into_inner()).map(Box::new))
+                .collect::<ParseResult<Vec<Box<Expression>>>>()?;
+
+            Function::Max(args)
+        }
         rule => unreachable!("Expected function name, got :{:?}", rule),
     };
     Ok(function)
@@ -317,6 +333,27 @@ mod tests {
                 Box::new(Expression::Decimal(123.into())),
                 None,
             )),
+        );
+    }
+
+    #[test]
+    fn test_min() {
+        parse_and_compare(
+            "MIN(1, 2)",
+            Expression::Function(Function::Min(vec![
+                Box::new(Expression::Decimal(1.into())),
+                Box::new(Expression::Decimal(2.into())),
+            ])),
+        );
+    }
+    #[test]
+    fn test_max() {
+        parse_and_compare(
+            "MAX(1, 2)",
+            Expression::Function(Function::Max(vec![
+                Box::new(Expression::Decimal(1.into())),
+                Box::new(Expression::Decimal(2.into())),
+            ])),
         );
     }
 }

--- a/expression-core/src/parser.rs
+++ b/expression-core/src/parser.rs
@@ -26,8 +26,8 @@ pub enum Function {
     Ceil(Box<Expression>, Option<Box<Expression>>),
     Round(Box<Expression>, Option<Box<Expression>>),
     Floor(Box<Expression>, Option<Box<Expression>>),
-    Min(Vec<Box<Expression>>),
-    Max(Vec<Box<Expression>>),
+    Min(Vec<Expression>),
+    Max(Vec<Expression>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -87,15 +87,15 @@ fn parse_function(pairs: Pairs<Rule>) -> ParseResult<Function> {
         Rule::floor => parse_function_with_args(Function::Floor, iter)?,
         Rule::min => {
            let args = iter
-                .map(|r| parse_expr(r.into_inner()).map(Box::new))
-                .collect::<ParseResult<Vec<Box<Expression>>>>()?;
+                .map(|r| parse_expr(r.into_inner()))
+                .collect::<ParseResult<Vec<Expression>>>()?;
 
             Function::Min(args)
         }
         Rule::max => {
             let args = iter
-                .map(|r| parse_expr(r.into_inner()).map(Box::new))
-                .collect::<ParseResult<Vec<Box<Expression>>>>()?;
+                .map(|r| parse_expr(r.into_inner()))
+                .collect::<ParseResult<Vec<Expression>>>()?;
 
             Function::Max(args)
         }
@@ -341,8 +341,8 @@ mod tests {
         parse_and_compare(
             "MIN(1, 2)",
             Expression::Function(Function::Min(vec![
-                Box::new(Expression::Decimal(1.into())),
-                Box::new(Expression::Decimal(2.into())),
+                Expression::Decimal(1.into()),
+                Expression::Decimal(2.into()),
             ])),
         );
     }
@@ -351,8 +351,8 @@ mod tests {
         parse_and_compare(
             "MAX(1, 2)",
             Expression::Function(Function::Max(vec![
-                Box::new(Expression::Decimal(1.into())),
-                Box::new(Expression::Decimal(2.into())),
+                Expression::Decimal(1.into()),
+                Expression::Decimal(2.into()),
             ])),
         );
     }

--- a/expression-ruby/Gemfile.lock
+++ b/expression-ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lago-expression (0.1.5)
+    lago-expression (0.1.6)
       bigdecimal
       rake (~> 13)
       rake-compiler (~> 1.2)

--- a/expression-ruby/spec/lago-expression/expression_spec.rb
+++ b/expression-ruby/spec/lago-expression/expression_spec.rb
@@ -85,5 +85,37 @@ RSpec.describe Lago::Expression do
         expect(expression.evaluate(event)).to eq(10)
       end
     end
+
+    context "with min function property value higher" do
+      let(:expression) { Lago::ExpressionParser.parse("min(event.properties.property_3, 5.0)") }
+
+      it "gets the provided min" do
+        expect(expression.evaluate(event)).to eq(5.0)
+      end
+    end
+
+    context "with min function property value lower" do
+      let(:expression) { Lago::ExpressionParser.parse("min(event.properties.property_3, 15.0)") }
+
+      it "gets the property value" do
+        expect(expression.evaluate(event)).to eq(12.34)
+      end
+    end
+
+    context "with max function property value higher" do
+      let(:expression) { Lago::ExpressionParser.parse("max(event.properties.property_3, 5.0)") }
+
+      it "gets the property value" do
+        expect(expression.evaluate(event)).to eq(12.34)
+      end
+    end
+
+    context "with max function property value lower" do
+      let(:expression) { Lago::ExpressionParser.parse("max(event.properties.property_3, 15.0)") }
+
+      it "gets the provided value" do
+        expect(expression.evaluate(event)).to eq(15.0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Add min / max expression which are quite handy to use in SQL expressions in billable metrics.

[This](https://github.com/getlago/lago-doc/pull/454) is the relevant doc update PR.