### PR TITLE
misc: Bump version to 0.2.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Ruby 3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4.2"
+          ruby-version: "3.4.7"
       - name: install dependencies
         run: bundle install
       - name: build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.4.2
-nodejs 22.11.0
+ruby 3.4.7
+nodejs 24.11.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "expression-core"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "bigdecimal",
  "lazy_static",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "expression-go"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "expression-core",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "lago-expression"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "bigdecimal",
  "console_error_panic_hook",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "lago_expression"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "expression-core",
  "magnus",
@@ -567,18 +567,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.111"
+version = "0.9.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "becea799ce051c16fb140be80f5e7cf781070f99ca099332383c2b17861249af"
+checksum = "45fb1a185af97ee456f1c9e56dbe6e2e662bec4fdeaf83c4c28e0e6adfb18816"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.111"
+version = "0.9.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64691175abc704862f60a9ca8ef06174080cc50615f2bf1d4759f46db18b4d29"
+checksum = "a58ebd02d7a6033e6a5f6f8d150c1e9f16506039092b84a73e6bedce6d3adf41"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/expression-core/Cargo.toml
+++ b/expression-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expression-core"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/expression-go/Cargo.toml
+++ b/expression-go/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expression-go"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/expression-js/Cargo.toml
+++ b/expression-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago-expression"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/expression-ruby/Gemfile
+++ b/expression-ruby/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-ruby "3.4.2"
+ruby "3.4.7"
 
 gemspec

--- a/expression-ruby/Gemfile.lock
+++ b/expression-ruby/Gemfile.lock
@@ -1,11 +1,11 @@
 PATH
   remote: .
   specs:
-    lago-expression (0.1.6)
+    lago-expression (0.2.0)
       bigdecimal
       rake (~> 13)
       rake-compiler (~> 1.2)
-      rb_sys (~> 0.9.111)
+      rb_sys (~> 0.9.123)
 
 GEM
   remote: https://rubygems.org/
@@ -15,9 +15,9 @@ GEM
     rake (13.2.1)
     rake-compiler (1.2.8)
       rake
-    rake-compiler-dock (1.9.1)
-    rb_sys (0.9.111)
-      rake-compiler-dock (= 1.9.1)
+    rake-compiler-dock (1.10.0)
+    rb_sys (0.9.123)
+      rake-compiler-dock (= 1.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -44,7 +44,7 @@ DEPENDENCIES
   rspec (~> 3)
 
 RUBY VERSION
-   ruby 3.4.2p28
+   ruby 3.4.7p58
 
 BUNDLED WITH
    2.5.11

--- a/expression-ruby/ext/lago_expression/Cargo.toml
+++ b/expression-ruby/ext/lago_expression/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lago_expression"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/expression-ruby/lago-expression.gemspec
+++ b/expression-ruby/lago-expression.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'lago-expression'
-  spec.version = '0.1.6'
+  spec.version = '0.2.0'
   spec.summary = 'gem supporting sql expression evaluation in ruby'
   spec.authors = ['Lago']
   spec.required_ruby_version = '~> 3.4'
@@ -14,6 +14,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bigdecimal'
   spec.add_dependency 'rake', '~> 13'
   spec.add_dependency 'rake-compiler', '~> 1.2'
-  spec.add_dependency 'rb_sys', '~> 0.9.111'
+  spec.add_dependency 'rb_sys', '~> 0.9.123'
   spec.add_development_dependency 'rspec', '~> 3'
 end

--- a/expression-ruby/lib/lago-expression.rb
+++ b/expression-ruby/lib/lago-expression.rb
@@ -3,5 +3,5 @@ require 'bigdecimal/util'
 require_relative 'lago_expression/lago_expression'
 
 module Lago
-  VERSION = '0.1.6'.freeze
+  VERSION = '0.2.0'.freeze
 end


### PR DESCRIPTION
This PR updates some dependencies and prepares the release of the version 0.2.0 of this library.

This new release will include the new min/max functions added with https://github.com/getlago/lago-expression/pull/17