### PR TITLE
fix: Replace `min/max` by `least/greatest`

### DIFF
--- a/expression-core/src/evaluate.rs
+++ b/expression-core/src/evaluate.rs
@@ -118,22 +118,24 @@ impl Function {
                 event,
                 RoundingMode::Floor,
             ),
-            Function::Min(args) => {
+            Function::Least(args) => {
                 let min_value = args
                     .iter()
                     .map(|e| e.evaluate(event).and_then(|v| v.to_decimal()))
                     .collect::<EvaluationResult<Vec<BigDecimal>>>()?
                     .into_iter()
-                    .min().ok_or(ExpressionError::EmptyArgumentList)?;
+                    .min()
+                    .ok_or(ExpressionError::EmptyArgumentList)?;
                 Ok(ExpressionValue::Number(min_value))
             }
-            Function::Max(args) => {
+            Function::Greatest(args) => {
                 let max_value = args
                     .iter()
                     .map(|e| e.evaluate(event).and_then(|v| v.to_decimal()))
                     .collect::<EvaluationResult<Vec<BigDecimal>>>()?
                     .into_iter()
-                    .max().ok_or(ExpressionError::EmptyArgumentList)?;
+                    .max()
+                    .ok_or(ExpressionError::EmptyArgumentList)?;
                 Ok(ExpressionValue::Number(max_value))
             }
         }

--- a/expression-core/src/grammar.pest
+++ b/expression-core/src/grammar.pest
@@ -1,12 +1,12 @@
 function = { function_name ~ "(" ~ function_args ~ ")" }
 
-function_name = _{ ceil | concat | round | floor | min | max }
+function_name = _{ ceil | concat | round | floor | least | greatest }
 ceil          =  { "ceil" | "CEIL" | "Ceil" }
 concat        =  { "concat" | "CONCAT" | "Concat" }
 round         =  { "round" | "ROUND" | "Round" }
 floor         =  { "floor" | "FLOOR" | "Floor" }
-min           =  {"min" | "MIN" | "Min"}
-max           =  {"max" | "MAX" | "Max"}
+least         =  {"least" | "LEAST" | "Least"}
+greatest      =  {"greatest" | "GREATEST" | "Greatest"}
 
 function_args = _{ expr ~ ("," ~ expr)* }
 

--- a/expression-core/src/parser.rs
+++ b/expression-core/src/parser.rs
@@ -26,8 +26,8 @@ pub enum Function {
     Ceil(Box<Expression>, Option<Box<Expression>>),
     Round(Box<Expression>, Option<Box<Expression>>),
     Floor(Box<Expression>, Option<Box<Expression>>),
-    Min(Vec<Expression>),
-    Max(Vec<Expression>),
+    Least(Vec<Expression>),
+    Greatest(Vec<Expression>),
 }
 
 #[derive(Debug, PartialEq)]
@@ -85,19 +85,19 @@ fn parse_function(pairs: Pairs<Rule>) -> ParseResult<Function> {
         Rule::ceil => parse_function_with_args(Function::Ceil, iter)?,
         Rule::round => parse_function_with_args(Function::Round, iter)?,
         Rule::floor => parse_function_with_args(Function::Floor, iter)?,
-        Rule::min => {
-           let args = iter
-                .map(|r| parse_expr(r.into_inner()))
-                .collect::<ParseResult<Vec<Expression>>>()?;
-
-            Function::Min(args)
-        }
-        Rule::max => {
+        Rule::least => {
             let args = iter
                 .map(|r| parse_expr(r.into_inner()))
                 .collect::<ParseResult<Vec<Expression>>>()?;
 
-            Function::Max(args)
+            Function::Least(args)
+        }
+        Rule::greatest => {
+            let args = iter
+                .map(|r| parse_expr(r.into_inner()))
+                .collect::<ParseResult<Vec<Expression>>>()?;
+
+            Function::Greatest(args)
         }
         rule => unreachable!("Expected function name, got :{:?}", rule),
     };
@@ -337,20 +337,20 @@ mod tests {
     }
 
     #[test]
-    fn test_min() {
+    fn test_least() {
         parse_and_compare(
-            "MIN(1, 2)",
-            Expression::Function(Function::Min(vec![
+            "LEAST(1, 2)",
+            Expression::Function(Function::Least(vec![
                 Expression::Decimal(1.into()),
                 Expression::Decimal(2.into()),
             ])),
         );
     }
     #[test]
-    fn test_max() {
+    fn test_greatest() {
         parse_and_compare(
-            "MAX(1, 2)",
-            Expression::Function(Function::Max(vec![
+            "GREATEST(1, 2)",
+            Expression::Function(Function::Greatest(vec![
                 Expression::Decimal(1.into()),
                 Expression::Decimal(2.into()),
             ])),

--- a/expression-ruby/spec/lago-expression/expression_spec.rb
+++ b/expression-ruby/spec/lago-expression/expression_spec.rb
@@ -86,34 +86,34 @@ RSpec.describe Lago::Expression do
       end
     end
 
-    context "with min function property value higher" do
-      let(:expression) { Lago::ExpressionParser.parse("min(event.properties.property_3, 5.0)") }
+    context "with least function property value higher" do
+      let(:expression) { Lago::ExpressionParser.parse("least(event.properties.property_3, 5.0)") }
 
-      it "gets the provided min" do
+      it "gets the lowest value" do
         expect(expression.evaluate(event)).to eq(5.0)
       end
     end
 
-    context "with min function property value lower" do
-      let(:expression) { Lago::ExpressionParser.parse("min(event.properties.property_3, 15.0)") }
+    context "with least function property value lower" do
+      let(:expression) { Lago::ExpressionParser.parse("least(event.properties.property_3, 15.0)") }
 
-      it "gets the property value" do
+      it "gets the lowest value" do
         expect(expression.evaluate(event)).to eq(12.34)
       end
     end
 
-    context "with max function property value higher" do
-      let(:expression) { Lago::ExpressionParser.parse("max(event.properties.property_3, 5.0)") }
+    context "with greatest function property value higher" do
+      let(:expression) { Lago::ExpressionParser.parse("greatest(event.properties.property_3, 5.0)") }
 
-      it "gets the property value" do
+      it "gets the greatest value" do
         expect(expression.evaluate(event)).to eq(12.34)
       end
     end
 
-    context "with max function property value lower" do
-      let(:expression) { Lago::ExpressionParser.parse("max(event.properties.property_3, 15.0)") }
+    context "with greatest function property value lower" do
+      let(:expression) { Lago::ExpressionParser.parse("greatest(event.properties.property_3, 15.0)") }
 
-      it "gets the provided value" do
+      it "gets the greatest value" do
         expect(expression.evaluate(event)).to eq(15.0)
       end
     end


### PR DESCRIPTION
## Context

https://github.com/getlago/lago-expression/pull/17 introduced `min/max` but those names could be confused with the SQL aggregates.

## Description

We can reduce this confusion by adhering to SQL `LEAST/GREATEST` naming.
