### PR TITLE
fix(javascript): Setup Trusted Publishing for NPM

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -5,6 +5,10 @@ on:
     types: [released]
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -16,19 +20,17 @@ jobs:
         working-directory: ./expression-js
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-          registry-url: https://registry.npmjs.org/
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install dependencies
         run: npm i
       - name: Build
-        run: npm run build
+        run: npm run build --if-present
       - name: Package
         run: wasm-pack pack
       - name: Publish
         run: wasm-pack publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/expression-js/package.json
+++ b/expression-js/package.json
@@ -4,6 +4,10 @@
     "build": "webpack",
     "serve": "webpack serve"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getlago/ago-expression.git"
+  },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.7.0",
     "html-webpack-plugin": "^5.6.0",


### PR DESCRIPTION
npmjs.com recently changed its security model regarding token without expiration date.

The new recommended approach for NPM publication from a github action is to use [Truster Publishers](https://docs.npmjs.com/trusted-publishers)

This PR is updating the config to use this new approach